### PR TITLE
Changed typst-pdf-preview-command to be determined by operating syste…

### DIFF
--- a/typst-mode.el
+++ b/typst-mode.el
@@ -86,7 +86,13 @@
   :type 'string
   :group 'typst-mode)
 
-(defcustom typst-pdf-preview-command  "xdg-open %s"
+(defun typst-pdf-preview-command-by-system ()
+  (cond
+   ((eq system-type 'darwin) "open %s") ;; mac os
+   ((eq system-type 'gnu-linux) "xdg-open %s")
+   ((eq system-type 'windows-nt) "start %s")))
+
+(defcustom typst-pdf-preview-command (typst-pdf-preview-command-by-system)
   "Command to open/preview pdf. %s stand for the pdf file name."
   :type 'string
   :group 'typst-mode)
@@ -585,10 +591,10 @@ If BACKWARD is non-nil, search backward instead of forward."
 
 (define-innermode typst--poly-math-innermode
   :mode 'typst--math-mode
-  ;; header-matcher: the first '$' on the line. 
+  ;; header-matcher: the first '$' on the line.
   ;; :head-matcher (cons (rx bol (* (not "$")) (group-n 1 "$") (* not-newline)) 1)
   ;; :head-matcher "\\$"
-  ;; tail-matcher: the second '$' on the line 
+  ;; tail-matcher: the second '$' on the line
   ;; :head-matcher 'typst--poly-math-find-head
   :tail-matcher 'typst--poly-math-find-tail
   :head-mode 'host


### PR DESCRIPTION
Eventually I would like to see support for pdf-tools as that is my preferred PDF viewer in emacs, but this at least makes pdf preview work on my Mac. I didn't test whether my code creates the correct string for opening PDFs on Windows, but I used this Stack Overflow answer to get the command: 

https://stackoverflow.com/questions/6557920/how-to-open-a-pdf-in-fullscreen-view-via-command-line-on-windows

Also, my emacs is set up to remove trailing whitespace on lines, so it removed two trailing whitespaces in comments.